### PR TITLE
feat: Add history and link opening preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,14 @@
     <button id="input-btn">SAVE INPUT</button>
     <button id="tab-btn">SAVE TAB</button>
     <button id="delete-btn">DELETE ALL</button>
+    <div>
+        <input type="checkbox" id="pref-newtab-checkbox">
+        <label for="pref-newtab-checkbox">Open links in new tab</label>
+    </div>
     <ul id="ul-el">
+    </ul>
+    <button id="history-btn">VIEW HISTORY</button>
+    <ul id="history-ul-el">
     </ul>
     <script src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -5,8 +5,38 @@ const inputEl = document.getElementById('input-el')
 const inputBtn = document.getElementById('input-btn')
 const ulEl = document.getElementById('ul-el')
 const deleteBtn = document.getElementById('delete-btn')
-const leadsFromLocalStorage = JSON.parse(localStorage.getItem("myLeads")) 
+const leadsFromLocalStorage = JSON.parse(localStorage.getItem("myLeads"))
 const tabBtn = document.getElementById('tab-btn')
+const newTabCheckbox = document.getElementById('pref-newtab-checkbox')
+
+// --- Link Preference Handling ---
+let openInNewTab = true; // Default value
+
+function loadPreference() {
+    const savedPref = localStorage.getItem("prefOpenInNewTab");
+    if (savedPref !== null) {
+        openInNewTab = JSON.parse(savedPref);
+    }
+    newTabCheckbox.checked = openInNewTab;
+}
+
+function savePreference() {
+    openInNewTab = newTabCheckbox.checked;
+    localStorage.setItem("prefOpenInNewTab", JSON.stringify(openInNewTab));
+    // Re-render lists to apply the change immediately
+    render(myLeads);
+    // Check if history is currently displayed and re-render it too
+    if (historyUlEl.innerHTML !== "") {
+        renderHistory();
+    }
+}
+
+// Load preference on script start
+loadPreference();
+
+// Save preference on change
+newTabCheckbox.addEventListener('change', savePreference);
+// --- End Link Preference Handling ---
 
 tabBtn.addEventListener("click", ()=> {
    //Grab url of current tab with chrome API
@@ -30,11 +60,12 @@ if (leadsFromLocalStorage) {
 }
 
 function render(leads) {
-   let listItems = "" 
+   let listItems = ""
+   const targetAttribute = openInNewTab ? "target='_blank'" : "";
    for (let i=0; i<leads.length; i++) {
       listItems += `
          <li>
-            <a target='_blank' href='${leads[i]}'>
+            <a ${targetAttribute} href='${leads[i]}'>
                ${leads[i]}
              </a>
          </li>
@@ -46,7 +77,16 @@ function render(leads) {
 
 deleteBtn.addEventListener("dblclick", ()=> {
    console.log("doubleclicked")
-   localStorage.clear()
+   // Get existing leads
+   const currentLeads = JSON.parse(localStorage.getItem("myLeads")) || [];
+   // Get existing old leads, initialize if null
+   let oldLeads = JSON.parse(localStorage.getItem("myOldLeads")) || [];
+   // Append current leads to old leads
+   oldLeads = oldLeads.concat(currentLeads);
+   // Save combined old leads
+   localStorage.setItem("myOldLeads", JSON.stringify(oldLeads));
+   // Clear current leads
+   localStorage.removeItem("myLeads"); // Use removeItem instead of clear to keep myOldLeads
    myLeads = []
    render(myLeads)
 })
@@ -57,3 +97,28 @@ inputBtn.addEventListener("click", ()=> {
     localStorage.setItem("myLeads", (JSON.stringify(myLeads)))
    render(myLeads)
 } )
+
+const historyBtn = document.getElementById('history-btn');
+const historyUlEl = document.getElementById('history-ul-el');
+
+function renderHistory() {
+    const oldLeads = JSON.parse(localStorage.getItem("myOldLeads")) || [];
+    let listItems = "";
+    const targetAttribute = openInNewTab ? "target='_blank'" : "";
+    if (oldLeads.length > 0) {
+        for (let i = 0; i < oldLeads.length; i++) {
+            listItems += `
+                <li>
+                    <a ${targetAttribute} href='${oldLeads[i]}'>
+                        ${oldLeads[i]}
+                    </a>
+                </li>
+            `;
+        }
+    } else {
+        listItems = "<li>No history yet.</li>";
+    }
+    historyUlEl.innerHTML = listItems;
+}
+
+historyBtn.addEventListener("click", renderHistory);


### PR DESCRIPTION
Adds two main features to the leads tracker extension:

1.  **Lead History:** When 'DELETE ALL' is used, leads are now moved to a history archive instead of being permanently deleted. A 'VIEW HISTORY' button allows you to see these archived leads.
2.  **Link Preference:** A checkbox allows you to choose whether saved links (in both the main list and history) open in a new tab (`target="_blank"`) or the current tab. This preference is saved in localStorage.

The implementation involves:
- Modifying the delete logic to use a separate localStorage key (`myOldLeads`) for history.
- Adding UI elements (buttons, list, checkbox) to `index.html`.
- Adding functions (`renderHistory`) and event listeners in `main.js` to handle history display and preference changes.
- Ensuring preference is loaded on startup and applied dynamically when rendering links.